### PR TITLE
(+semver: patch) Add kvetchctl to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,6 @@ FROM ubuntu:18.04 as final
 ENV GOMAXPROCS 128
 EXPOSE 7777
 WORKDIR /app
+COPY --from=0 /artifacts/linux/kvetchctl /app/
 COPY --from=0 /build/kvetch /app/
 CMD ["/app/kvetch"]

--- a/README.md
+++ b/README.md
@@ -7,17 +7,30 @@ Kvetch is a small gRPC wrapper around the [Badger](https://github.com/dgraph-io/
 Run the Kvetch container in Docker:
 
 ```bash
-docker run --rm -v $PWD/data:/data -e DATASTORE=/data -p 7777:7777  syncromatics/kvetch:0.4.0
+docker run --rm -v $PWD/data:/data -e DATASTORE=/data -p 7777:7777  syncromatics/kvetch:v0.5.1
 ```
 
 Interact with Kvetch using `kvetchctl`:
 
 ```bash
+GO111MODULE=on go get github.com/syncromatics/kvetch/cmd/kvetchctl@v0.5.1
 export KVETCHCTL_ENDPOINT=localhost:7777 # host:port of Kvetch instance
 kvetchctl set example/1 "first value"
 kvetchctl set example/2 "second value"
 kvetchctl set example/3 "third value"
 kvetchctl get --prefix example/
+```
+
+It is also possible to run both `kvetch` and `kvetchctl` in the same docker container:
+
+```bash
+docker run -it --rm syncromatics/kvetch:v0.5.1 bash
+DATASTORE=/data ./kvetch &
+export KVETCHCTL_ENDPOINT=localhost:7777
+./kvetchctl set example/1 "first value"
+./kvetchctl set example/2 "second value"
+./kvetchctl set example/3 "third value"
+./kvetchctl get --prefix example/
 ```
 
 More `kvetchctl` documentation is available in [docs/kvetchctl](docs/kvetchctl/kvetchctl.md)


### PR DESCRIPTION
## Description

This allows `kvetchctl` to be run from a docker container in the event that the user is unable or unwilling to install it locally.

The documentation has also been updated to fix the docker image tag format and show the installation of `kvetchctl` via `go get` since there were previously no installation instructions.

I also added a very simple example of running both `kvetch` and `kvetchctl` in a docker container. Other uses of `kvetchctl` from docker are beyond the scope of the readme. My intended use case is communicating with `kvetch` running in k8s and port-forwarded locally.