### PR TITLE
(+semver:feature) Add Badger configuration options for tweaking garbage collection aggressiveness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,78 @@ jobs:
           VERSION: ${{ steps.gogitver.outputs.version }}
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  pre-release:
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Prepare repository
+        run: git checkout "${GITHUB_REF:11}"
+
+      - uses: syncromatics/gogitver-action@v0.0.3
+        id: gogitver
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.gogitver.outputs.version }}
+          release_name: Release ${{ steps.gogitver.outputs.version }}
+          draft: false
+          prerelease: true
+
+      - uses: actions/checkout@v1
+
+      - name: Build release artifacts and ship Docker image
+        run: make package ship
+        env:
+          IMAGE: ${{github.repository}}
+          VERSION: ${{ steps.gogitver.outputs.version }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/linux.tar.gz
+          asset_name: linux.tar.gz
+          asset_content_type: application/gzip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/windows.zip
+          asset_name: windows.zip
+          asset_content_type: application/zip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/arm.tar.gz
+          asset_name: arm.tar.gz
+          asset_content_type: application/gzip
+
+      - uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./artifacts/darwin.tar.gz
+          asset_name: darwin.tar.gz
+          asset_content_type: application/gzip
+
   release:
     runs-on: ubuntu-latest
     needs: test

--- a/README.md
+++ b/README.md
@@ -35,6 +35,36 @@ export KVETCHCTL_ENDPOINT=localhost:7777
 
 More `kvetchctl` documentation is available in [docs/kvetchctl](docs/kvetchctl/kvetchctl.md)
 
+## Configuration
+
+Configuration is done via environmental variables. Refer to the tables below.
+
+**General Settings**
+
+| Name                        | Type     | Description                                              | Required | Default |
+| --------------------------- | -------- | -------------------------------------------------------- | -------- | ------- |
+| DATASTORE                   | string   | Directory where badger key data will be stored in.       | Yes      | `nil`   |
+| GARBAGE_COLLECTION_INTERVAL | duration | Defines how often kvetch will attempt garbage collection | No       | 5m      |
+| PORT                        | int      | Port on which kvetch grpc service will run.              | No       | 7777    |
+| PROMETHEUS_PORT             |          | Port for use by Prometheus for metric gathering.         | No       | 80      |
+
+**Optional BadgerDB Specific Settings** (More Detail @ https://github.com/dgraph-io/badger/blob/master/options.go)
+
+Default values here are set to BadgerDB defaults and subject to change if package is updated. Refer to above link for more info.
+
+| Name                                               | Type  | Description                                                  | Default |
+| -------------------------------------------------- | ----- | ------------------------------------------------------------ | ------- |
+| ENABLE_TRUNCATE                                    | bool  | Truncate indicates whether value log files should be truncated to delete corrupt data, if any. | False   |
+| GARBAGE_COLLECTION_DISCARD_RATIO                   | float | Percentage of value log file that has to be expired or ready for garbage collection for that file to be eligible for garbage collection. | 0.5     |
+| LEVEL_ONE_SIZE                                     | int   | The maximum total size in bytes for Level 1 in the LSM.      | 20MB    |
+| LEVEL_SIZE_MULTIPLIER                              | int   | Sets the ratio between the maximum sizes of contiguous levels in the LSM. Once a level grows to be larger than this ratio allowed, the compaction process will be triggered. | 10      |
+| MAX_TABLE_SIZE                                     | int   | Sets the maximum size in bytes for each LSM table or file.   | 64MB    |
+| NUMBER_OF_LEVEL_ZERO_TABLES                        | int   | Maximum number of Level 0 tables before compaction starts.   | 5       |
+| NUMBER_OF_ZERO_LEVEL_TABLES_UNTIL_FORCE_COMPACTION | int   | Sets the number of Level 0 tables that once reached causes the DB to stall until compaction succeeds. | 10      |
+
+
+
+
 ## Building
 
 [![build](https://github.com/syncromatics/kvetch/workflows/build/badge.svg)](https://github.com/syncromatics/kvetch/actions?query=workflow%3Abuild)

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Configuration is done via environmental variables. Refer to the tables below.
 
 **General Settings**
 
-| Name                        | Type     | Description                                              | Required | Default |
-| --------------------------- | -------- | -------------------------------------------------------- | -------- | ------- |
-| DATASTORE                   | string   | Directory where badger key data will be stored in.       | Yes      | `nil`   |
-| GARBAGE_COLLECTION_INTERVAL | duration | Defines how often kvetch will attempt garbage collection | No       | 5m      |
-| PORT                        | int      | Port on which kvetch grpc service will run.              | No       | 7777    |
-| PROMETHEUS_PORT             |          | Port for use by Prometheus for metric gathering.         | No       | 80      |
+| Name                        | Type     | Description                                               | Required | Default |
+| --------------------------- | -------- | --------------------------------------------------------- | -------- | ------- |
+| DATASTORE                   | string   | Directory where badger key data will be stored in.        | Yes      | `nil`   |
+| GARBAGE_COLLECTION_INTERVAL | duration | Defines how often kvetch will attempt garbage collection. | No       | 5m      |
+| PORT                        | int      | Port on which kvetch grpc service will run.               | No       | 7777    |
+| PROMETHEUS_PORT             | int      | Port for use by Prometheus for metric gathering.          | No       | 80      |
 
 **Optional BadgerDB Specific Settings** (More Detail @ https://github.com/dgraph-io/badger/blob/master/options.go)
 

--- a/cmd/kvetch/main.go
+++ b/cmd/kvetch/main.go
@@ -22,7 +22,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	kvstore, err := datastore.NewKVStore(settings.Datastore)
+	kvstore, err := datastore.NewKVStore(settings.Datastore, settings.KVStoreOptions)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/kvetch/settings.go
+++ b/cmd/kvetch/settings.go
@@ -6,6 +6,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	kvstore "github.com/syncromatics/kvetch/internal/datastore"
 )
 
 type settings struct {
@@ -13,6 +16,81 @@ type settings struct {
 	PrometheusPort            int
 	Datastore                 string
 	GarbageCollectionInterval time.Duration
+	KVStoreOptions            *kvstore.KVStoreOptions
+}
+
+func getKVStoreOptions() (*kvstore.KVStoreOptions, error) {
+	allErrors := []string{}
+	kvStoreOptions := &kvstore.KVStoreOptions{}
+	enableTruncateString, ok := os.LookupEnv("ENABLE_TRUNCATE")
+	if ok {
+		enableTruncate, err := strconv.ParseBool(enableTruncateString)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("ENABLE_TRUNCATE is not a valid bool '%s'", enableTruncateString))
+		} else {
+			kvStoreOptions.EnableTruncate = &wrappers.BoolValue{Value: enableTruncate}
+		}
+	}
+	maxTableSizeString, ok := os.LookupEnv("MAX_TABLE_SIZE")
+	if ok {
+		maxTableSize, err := strconv.ParseInt(maxTableSizeString, 10, 64)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("MAX_TABLE_SIZE is not a valid int64 '%s'", maxTableSizeString))
+		} else {
+			kvStoreOptions.MaxTableSize = &wrappers.Int64Value{Value: maxTableSize}
+		}
+	}
+	levelOneSizeString, ok := os.LookupEnv("LEVEL_ONE_SIZE")
+	if ok {
+		levelOneSize, err := strconv.ParseInt(levelOneSizeString, 10, 64)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("LEVEL_ONE_SIZE is not a valid int64 '%s'", levelOneSizeString))
+		} else {
+			kvStoreOptions.LevelOneSize = &wrappers.Int64Value{Value: levelOneSize}
+		}
+	}
+	levelSizeMultiplierString, ok := os.LookupEnv("LEVEL_SIZE_MULTIPLIER")
+	if ok {
+		levelSizeMultiplier, err := strconv.ParseInt(levelSizeMultiplierString, 10, 32)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("LEVEL_SIZE_MULTIPLIER is not a valid int32 '%s'", levelSizeMultiplierString))
+		} else {
+			kvStoreOptions.LevelSizeMultiplier = &wrappers.Int32Value{Value: int32(levelSizeMultiplier)}
+		}
+	}
+	numberOfLevelZeroTablesString, ok := os.LookupEnv("NUMBER_OF_LEVEL_ZERO_TABLES")
+	if ok {
+		numberOfLevelZeroTables, err := strconv.ParseInt(numberOfLevelZeroTablesString, 10, 32)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("NUMBER_OF_LEVEL_ZERO_TABLES is not a valid int32 '%s'", numberOfLevelZeroTablesString))
+		} else {
+			kvStoreOptions.NumberOfLevelZeroTables = &wrappers.Int32Value{Value: int32(numberOfLevelZeroTables)}
+		}
+	}
+	numberOfLevelZeroTablesUntilForceCompactionString, ok := os.LookupEnv("NUMBER_OF_ZERO_LEVEL_TABLES_UNTIL_FORCE_COMPACTION")
+	if ok {
+		numberOfLevelZeroTablesUntilForceCompactaion, err := strconv.ParseInt(numberOfLevelZeroTablesUntilForceCompactionString, 10, 32)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("NUMBER_OF_ZERO_LEVEL_TABLES_UNTIL_FORCE_COMPACTION is not a valid int32 '%s'", numberOfLevelZeroTablesUntilForceCompactionString))
+		} else {
+			kvStoreOptions.NumberOfLevelZeroTablesUntilForceCompaction = &wrappers.Int32Value{Value: int32(numberOfLevelZeroTablesUntilForceCompactaion)}
+		}
+	}
+	garbageCollectionDiscardRatioString, ok := os.LookupEnv("GARBAGE_COLLECTION_DISCARD_RATIO")
+	if ok {
+		garbageCollectionDiscardRatio, err := strconv.ParseFloat(garbageCollectionDiscardRatioString, 32)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("GARBAGE_COLLECTION_DISCARD_RATIO is not a valid float32 '%s'", garbageCollectionDiscardRatioString))
+		} else {
+			kvStoreOptions.GarbageCollectionDiscardRatio = &wrappers.FloatValue{Value: float32(garbageCollectionDiscardRatio)}
+		}
+	}
+
+	if len(allErrors) > 0 {
+		return nil, fmt.Errorf("Failed configuring KVStore: %s", strings.Join(allErrors, ", "))
+	}
+
+	return kvStoreOptions, nil
 }
 
 func getSettingsFromEnv() (*settings, error) {
@@ -55,6 +133,11 @@ func getSettingsFromEnv() (*settings, error) {
 		}
 	}
 
+	kvStoreOptions, err := getKVStoreOptions()
+	if err != nil {
+		allErrors = append(allErrors, err.Error())
+	}
+
 	if len(allErrors) > 0 {
 		return nil, fmt.Errorf("Missing required environment variables: %s", strings.Join(allErrors, ", "))
 	}
@@ -64,5 +147,6 @@ func getSettingsFromEnv() (*settings, error) {
 		PrometheusPort:            prometheusPortInt,
 		Datastore:                 datastore,
 		GarbageCollectionInterval: duration,
+		KVStoreOptions:            kvStoreOptions,
 	}, nil
 }

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -19,7 +19,8 @@ type KVStore struct {
 // NewKVStore creates a new key value datastore
 func NewKVStore(path string) (*KVStore, error) {
 	opts := badger.DefaultOptions(path)
-	db, err := badger.Open(opts.WithTruncate(true))
+	db, err := badger.Open(opts.WithTruncate(true).
+		WithMaxTableSize(4194304).WithLevelOneSize(8388608).WithLevelSizeMultiplier(2).WithNumLevelZeroTables(1).WithNumLevelZeroTablesStall(2))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open datastore")
 	}
@@ -168,7 +169,7 @@ func (s *KVStore) Subscribe(ctx context.Context, subscription *apiv1.SubscribeRe
 
 // GarbageCollect cleans up old values in log files
 func (s *KVStore) GarbageCollect() error {
-	err := s.db.RunValueLogGC(0.5)
+	err := s.db.RunValueLogGC(0.25)
 	if err == badger.ErrNoRewrite { // no cleanup happened, this is okay
 		return nil
 	}

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -18,7 +18,9 @@ type KVStore struct {
 
 // NewKVStore creates a new key value datastore
 func NewKVStore(path string) (*KVStore, error) {
-	db, err := badger.Open(badger.DefaultOptions(path))
+	opts := badger.DefaultOptions(path)
+	opts.WithTruncate(true)
+	db, err := badger.Open(opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open datastore")
 	}

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -33,11 +33,11 @@ type KVStore struct {
 func getBadgerOptions(path string, options *KVStoreOptions) badger.Options {
 	opts := badger.DefaultOptions(path)
 	if options.EnableTruncate != nil {
-		fmt.Printf("Configuring with enableTruncate: %t \n", options.EnableTruncate.Value)
+		fmt.Printf("Configuring with EnableTruncate: %t \n", options.EnableTruncate.Value)
 		opts = opts.WithTruncate(options.EnableTruncate.Value)
 	}
 	if options.MaxTableSize != nil {
-		fmt.Printf("Configuring with maxTableSize: %d \n", options.MaxTableSize.Value)
+		fmt.Printf("Configuring with MaxTableSize: %d \n", options.MaxTableSize.Value)
 		opts = opts.WithMaxTableSize(options.MaxTableSize.Value)
 	}
 	if options.LevelOneSize != nil {
@@ -64,7 +64,7 @@ func getBadgerOptions(path string, options *KVStoreOptions) badger.Options {
 func NewKVStore(path string, options *KVStoreOptions) (*KVStore, error) {
 	garbageCollectionDiscardRatio := 0.5
 	if options.GarbageCollectionDiscardRatio != nil {
-		fmt.Printf("Configuring with garbageCollectionDiscardRatio: %f \n", options.GarbageCollectionDiscardRatio.Value)
+		fmt.Printf("Configuring with GarbageCollectionDiscardRatio: %f \n", options.GarbageCollectionDiscardRatio.Value)
 		garbageCollectionDiscardRatio = float64(options.GarbageCollectionDiscardRatio.Value)
 	}
 

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -2,30 +2,80 @@ package datastore
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	apiv1 "github.com/syncromatics/kvetch/internal/protos/kvetch/api/v1"
 
 	badger "github.com/dgraph-io/badger/v2"
 	"github.com/pkg/errors"
 )
 
+//KVStoreOptions represent environment variable configurable options related to the KV Store.
+type KVStoreOptions struct {
+	EnableTruncate                              *wrappers.BoolValue
+	MaxTableSize                                *wrappers.Int64Value
+	LevelOneSize                                *wrappers.Int64Value
+	LevelSizeMultiplier                         *wrappers.Int32Value
+	NumberOfLevelZeroTables                     *wrappers.Int32Value
+	NumberOfLevelZeroTablesUntilForceCompaction *wrappers.Int32Value
+	GarbageCollectionDiscardRatio               *wrappers.FloatValue
+}
+
 // KVStore is the key value datastore
 type KVStore struct {
-	db *badger.DB
+	db                            *badger.DB
+	garbageCollectionDiscardRatio float64
+}
+
+func getBadgerOptions(path string, options *KVStoreOptions) badger.Options {
+	opts := badger.DefaultOptions(path)
+	if options.EnableTruncate != nil {
+		fmt.Printf("Configuring with enableTruncate: %t \n", options.EnableTruncate.Value)
+		opts = opts.WithTruncate(options.EnableTruncate.Value)
+	}
+	if options.MaxTableSize != nil {
+		fmt.Printf("Configuring with maxTableSize: %d \n", options.MaxTableSize.Value)
+		opts = opts.WithMaxTableSize(options.MaxTableSize.Value)
+	}
+	if options.LevelOneSize != nil {
+		fmt.Printf("Configuring with LevelOneSize: %d \n", options.LevelOneSize.Value)
+		opts = opts.WithLevelOneSize(options.LevelOneSize.Value)
+	}
+	if options.LevelSizeMultiplier != nil {
+		fmt.Printf("Configuring with LevelSizeMultiplier: %d \n", options.LevelSizeMultiplier.Value)
+		opts = opts.WithLevelSizeMultiplier(int(options.LevelSizeMultiplier.Value))
+	}
+	if options.NumberOfLevelZeroTables != nil {
+		fmt.Printf("Configuring with NumberOfLevelZeroTables: %d \n", options.NumberOfLevelZeroTables.Value)
+		opts = opts.WithNumLevelZeroTables(int(options.NumberOfLevelZeroTables.Value))
+	}
+	if options.NumberOfLevelZeroTablesUntilForceCompaction != nil {
+		fmt.Printf("Configuring with NumberOfLevelZeroTablesUntilForceCompaction: %d \n", options.NumberOfLevelZeroTablesUntilForceCompaction.Value)
+		opts = opts.WithNumLevelZeroTablesStall(int(options.NumberOfLevelZeroTablesUntilForceCompaction.Value))
+	}
+
+	return opts
 }
 
 // NewKVStore creates a new key value datastore
-func NewKVStore(path string) (*KVStore, error) {
-	opts := badger.DefaultOptions(path)
-	db, err := badger.Open(opts.WithTruncate(true).
-		WithMaxTableSize(4194304).WithLevelOneSize(8388608).WithLevelSizeMultiplier(2).WithNumLevelZeroTables(1).WithNumLevelZeroTablesStall(2))
+func NewKVStore(path string, options *KVStoreOptions) (*KVStore, error) {
+	garbageCollectionDiscardRatio := 0.5
+	if options.GarbageCollectionDiscardRatio != nil {
+		fmt.Printf("Configuring with garbageCollectionDiscardRatio: %f \n", options.GarbageCollectionDiscardRatio.Value)
+		garbageCollectionDiscardRatio = float64(options.GarbageCollectionDiscardRatio.Value)
+	}
+
+	opts := getBadgerOptions(path, options)
+	db, err := badger.Open(opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open datastore")
 	}
 	return &KVStore{
 		db,
+		garbageCollectionDiscardRatio,
 	}, nil
 }
 
@@ -169,7 +219,7 @@ func (s *KVStore) Subscribe(ctx context.Context, subscription *apiv1.SubscribeRe
 
 // GarbageCollect cleans up old values in log files
 func (s *KVStore) GarbageCollect() error {
-	err := s.db.RunValueLogGC(0.25)
+	err := s.db.RunValueLogGC(s.garbageCollectionDiscardRatio)
 	if err == badger.ErrNoRewrite { // no cleanup happened, this is okay
 		return nil
 	}

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -19,8 +19,7 @@ type KVStore struct {
 // NewKVStore creates a new key value datastore
 func NewKVStore(path string) (*KVStore, error) {
 	opts := badger.DefaultOptions(path)
-	opts.WithTruncate(true)
-	db, err := badger.Open(opts)
+	db, err := badger.Open(opts.WithTruncate(true))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open datastore")
 	}

--- a/internal/datastore/kvstore_test.go
+++ b/internal/datastore/kvstore_test.go
@@ -19,7 +19,7 @@ func Test_GetPrefix(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "Test_GetPrefix")
 	assert.NilError(t, err)
 
-	store, err := datastore.NewKVStore(tmpDir)
+	store, err := datastore.NewKVStore(tmpDir, &datastore.KVStoreOptions{})
 	assert.NilError(t, err)
 
 	err = store.Set(&apiv1.SetValuesRequest{
@@ -68,7 +68,7 @@ func Test_Get(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "Test_GetPrefix")
 	assert.NilError(t, err)
 
-	store, err := datastore.NewKVStore(tmpDir)
+	store, err := datastore.NewKVStore(tmpDir, &datastore.KVStoreOptions{})
 	assert.NilError(t, err)
 
 	err = store.Set(&apiv1.SetValuesRequest{
@@ -126,7 +126,7 @@ func Test_TTL(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "Test_GetPrefix")
 	assert.NilError(t, err)
 
-	store, err := datastore.NewKVStore(tmpDir)
+	store, err := datastore.NewKVStore(tmpDir, &datastore.KVStoreOptions{})
 	assert.NilError(t, err)
 
 	ttl := 2 * time.Second
@@ -203,7 +203,7 @@ func Test_Subscribe(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "Test_GetPrefix")
 	assert.NilError(t, err)
 
-	store, err := datastore.NewKVStore(tmpDir)
+	store, err := datastore.NewKVStore(tmpDir, &datastore.KVStoreOptions{})
 	assert.NilError(t, err)
 
 	values := []*apiv1.KeyValue{}


### PR DESCRIPTION
Adds a number of dgraph badger settings, configurable via env variables, designed to give kvetch users the ability to tweak settings related to garbage collection and LSM compaction.

Add pre-release step for pushing docker images to dockerhub