### PR TITLE
Feature/Add InMemory setting to config to allow diskless usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Default values here are set to BadgerDB defaults and subject to change if packag
 | -------------------------------------------------- | ----- | ------------------------------------------------------------ | ------- |
 | ENABLE_TRUNCATE                                    | bool  | Truncate indicates whether value log files should be truncated to delete corrupt data, if any. | False   |
 | GARBAGE_COLLECTION_DISCARD_RATIO                   | float | Percentage of value log file that has to be expired or ready for garbage collection for that file to be eligible for garbage collection. | 0.5     |
-| IN_MEMORY                                          | bool  | Sets InMemory mode to true. Everything is stored in memory. No value/sst files are created. In case of a crash all data will be lost. | false   |
+| IN_MEMORY                                          | bool  | Sets InMemory mode to true. Everything is stored in memory. No value/sst files on disk are created. In case of a crash all data will be lost. | false   |
 | LEVEL_ONE_SIZE                                     | int   | The maximum total size in bytes for Level 1 in the LSM.      | 20MB    |
 | LEVEL_SIZE_MULTIPLIER                              | int   | Sets the ratio between the maximum sizes of contiguous levels in the LSM. Once a level grows to be larger than this ratio allowed, the compaction process will be triggered. | 10      |
 | MAX_TABLE_SIZE                                     | int   | Sets the maximum size in bytes for each LSM table or file.   | 64MB    |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Default values here are set to BadgerDB defaults and subject to change if packag
 | -------------------------------------------------- | ----- | ------------------------------------------------------------ | ------- |
 | ENABLE_TRUNCATE                                    | bool  | Truncate indicates whether value log files should be truncated to delete corrupt data, if any. | False   |
 | GARBAGE_COLLECTION_DISCARD_RATIO                   | float | Percentage of value log file that has to be expired or ready for garbage collection for that file to be eligible for garbage collection. | 0.5     |
-| IN_MEMORY                                          | bool  | Sets InMemory mode to true. Everything is stored in memory. No value/sst files on disk are created. In case of a crash all data will be lost. | false   |
+| IN_MEMORY                                          | bool  | Sets InMemory mode to true. Everything is stored in memory. No value/sst files on disk are created. In case of a crash all data will be lost. | False   |
 | LEVEL_ONE_SIZE                                     | int   | The maximum total size in bytes for Level 1 in the LSM.      | 20MB    |
 | LEVEL_SIZE_MULTIPLIER                              | int   | Sets the ratio between the maximum sizes of contiguous levels in the LSM. Once a level grows to be larger than this ratio allowed, the compaction process will be triggered. | 10      |
 | MAX_TABLE_SIZE                                     | int   | Sets the maximum size in bytes for each LSM table or file.   | 64MB    |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Default values here are set to BadgerDB defaults and subject to change if packag
 | -------------------------------------------------- | ----- | ------------------------------------------------------------ | ------- |
 | ENABLE_TRUNCATE                                    | bool  | Truncate indicates whether value log files should be truncated to delete corrupt data, if any. | False   |
 | GARBAGE_COLLECTION_DISCARD_RATIO                   | float | Percentage of value log file that has to be expired or ready for garbage collection for that file to be eligible for garbage collection. | 0.5     |
+| IN_MEMORY                                          | bool  | Sets InMemory mode to true. Everything is stored in memory. No value/sst files are created. In case of a crash all data will be lost. | false   |
 | LEVEL_ONE_SIZE                                     | int   | The maximum total size in bytes for Level 1 in the LSM.      | 20MB    |
 | LEVEL_SIZE_MULTIPLIER                              | int   | Sets the ratio between the maximum sizes of contiguous levels in the LSM. Once a level grows to be larger than this ratio allowed, the compaction process will be triggered. | 10      |
 | MAX_TABLE_SIZE                                     | int   | Sets the maximum size in bytes for each LSM table or file.   | 64MB    |

--- a/cmd/kvetch/settings.go
+++ b/cmd/kvetch/settings.go
@@ -22,6 +22,15 @@ type settings struct {
 func getKVStoreOptions() (*kvstore.KVStoreOptions, error) {
 	allErrors := []string{}
 	kvStoreOptions := &kvstore.KVStoreOptions{}
+	inMemoryString, ok := os.LookupEnv("IN_MEMORY")
+	if ok {
+		inMemory, err := strconv.ParseBool(inMemoryString)
+		if err != nil {
+			allErrors = append(allErrors, fmt.Sprintf("IN_MEMORY is not a valid bool '%s'", inMemoryString))
+		} else {
+			kvStoreOptions.InMemory = &wrappers.BoolValue{Value: inMemory}
+		}
+	}
 	enableTruncateString, ok := os.LookupEnv("ENABLE_TRUNCATE")
 	if ok {
 		enableTruncate, err := strconv.ParseBool(enableTruncateString)

--- a/cmd/kvetch/settings.go
+++ b/cmd/kvetch/settings.go
@@ -130,8 +130,13 @@ func getSettingsFromEnv() (*settings, error) {
 		}
 	}
 
+	kvStoreOptions, err := getKVStoreOptions()
+	if err != nil {
+		allErrors = append(allErrors, err.Error())
+	}
+
 	datastore, ok := os.LookupEnv("DATASTORE")
-	if !ok {
+	if !ok && !kvStoreOptions.InMemory.Value {
 		allErrors = append(allErrors, "DATASTORE")
 	}
 
@@ -142,11 +147,6 @@ func getSettingsFromEnv() (*settings, error) {
 		if err != nil {
 			allErrors = append(allErrors, fmt.Sprintf("GARBAGE_COLLECTION_INTERVAL is not a valid time.Duration '%s'", collection))
 		}
-	}
-
-	kvStoreOptions, err := getKVStoreOptions()
-	if err != nil {
-		allErrors = append(allErrors, err.Error())
 	}
 
 	if len(allErrors) > 0 {

--- a/cmd/kvetch/settings.go
+++ b/cmd/kvetch/settings.go
@@ -30,6 +30,8 @@ func getKVStoreOptions() (*kvstore.KVStoreOptions, error) {
 		} else {
 			kvStoreOptions.InMemory = &wrappers.BoolValue{Value: inMemory}
 		}
+	} else {
+		kvStoreOptions.InMemory = &wrappers.BoolValue{Value: false}
 	}
 	enableTruncateString, ok := os.LookupEnv("ENABLE_TRUNCATE")
 	if ok {

--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -22,6 +22,7 @@ type KVStoreOptions struct {
 	NumberOfLevelZeroTables                     *wrappers.Int32Value
 	NumberOfLevelZeroTablesUntilForceCompaction *wrappers.Int32Value
 	GarbageCollectionDiscardRatio               *wrappers.FloatValue
+	InMemory                                    *wrappers.BoolValue
 }
 
 // KVStore is the key value datastore
@@ -32,6 +33,10 @@ type KVStore struct {
 
 func getBadgerOptions(path string, options *KVStoreOptions) badger.Options {
 	opts := badger.DefaultOptions(path)
+	if options.InMemory != nil {
+		fmt.Printf("Configuring with InMemory: %t \n", options.InMemory.Value)
+		opts = opts.WithInMemory(options.InMemory.Value)
+	}
 	if options.EnableTruncate != nil {
 		fmt.Printf("Configuring with EnableTruncate: %t \n", options.EnableTruncate.Value)
 		opts = opts.WithTruncate(options.EnableTruncate.Value)


### PR DESCRIPTION
Adding the ability to configure the dbadger instance as an in memory instance which does not save files to disk. offers performance and better TTL expiration benefits for users who do not need hard persistence.