### PR TITLE
(+semver:fix) don't return nil after returning first of subscriptions initial values.

### DIFF
--- a/internal/datastore/kvstore.go
+++ b/internal/datastore/kvstore.go
@@ -178,8 +178,6 @@ func (s *KVStore) Subscribe(ctx context.Context, subscription *apiv1.SubscribeRe
 			if err != nil {
 				return errors.Wrap(err, "failed callback")
 			}
-
-			return nil
 		}
 		return nil
 	})


### PR DESCRIPTION
The subscribe call does a quick prefix scan for all of the topics included in the request to get all the values currently set. Then it returns these. There was a bug where it would return after the first search and thus never return initials for the rest of the topics and you would have to instead wait for updates to the topics afterwards, which is not good. small fix but big fix.